### PR TITLE
Reconfigure user home directory to make proper use of oh-my-zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ podman build -t nodejs-containerfile target/image
 ```
 
 This is useful for supporting a mixed mode where you want to have a streamlined CI process for producing images for your project, but would also like to make it easy for consumers of your project to build the images themselves without extra tooling.
+
+
+## Quick Commands to build images
+
+```bash
+cekit build --overrides images/cekit-builder.yaml podman --tag quay.io/etsauer/cekit-builder:dev
+```

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -6,15 +6,13 @@ metadata:
 components:
 - name: dev-tools
   container:
-    # image: image-registry.openshift-image-registry.svc:5000/devspaces-images/cekit-builder:latest 
+    # image: quay.io/cgruver0/che/cekit-builder:latest
     image: quay.io/etsauer/cekit-builder:dev
     memoryLimit: 6Gi
     mountSources: true
     env:
     - name: SHELL
       value: "/bin/zsh"
-    - name: HOME
-      value: "/projects/home"
     - name: VSCODE_DEFAULT_WORKSPACE
       value: "/projects/dev-workspace-utilities/dev-workspace-utilities.code-workspace"
     - name: GOPATH

--- a/image.yaml
+++ b/image.yaml
@@ -12,7 +12,8 @@ envs:
   value: /projects
 - name: BUILDAH_ISOLATION
   value: chroot
-
+- name: HOME
+  value: /home/user
 
 modules:
   repositories:

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -15,3 +15,15 @@ oc apply -f local-dev/devspaces-operator.yaml
 envsubst < local-dev/github-oauth-config-secret.yaml | oc apply -f -
 oc apply -f local-dev/devspaces-cr.yaml
 ```
+
+Now log in as a a developer user and do the following:
+
+1. Create a couple environment variables to specify your git author name and email.
+    ```bash
+    export USER_NAME=<Full Name>
+    export USER_EMAIL=<email>
+    ```
+1. Then apply this to your devspaces namespace
+    ```bash
+    envsubst < local-dev/gitconfig-cm.yaml | oc apply -f -
+    ```

--- a/local-dev/gitconfig-cm.yaml
+++ b/local-dev/gitconfig-cm.yaml
@@ -1,0 +1,15 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: profile
+  labels:
+    controller.devfile.io/mount-to-devworkspace: 'true'
+    controller.devfile.io/watch-configmap: 'true'
+  annotations:
+    controller.devfile.io/mount-as: subpath
+    controller.devfile.io/mount-path: /home/user
+data:
+  .gitconfig: |
+    [user]
+          name = ${USER_NAME}
+          email = ${USER_EMAIL}

--- a/modules/developer-base/module.yaml
+++ b/modules/developer-base/module.yaml
@@ -5,7 +5,6 @@ description: Adds the devfile developer-base from https://github.com/devfile/dev
 version: '17'
 
 packages:
-  manager: dnf
   manager_flags: "--disableplugin=subscription-manager --setopt=tsflags=nodocs --setopt=install_weak_deps=0"
   install:
   - compat-openssl11
@@ -32,6 +31,8 @@ packages:
   - buildah
   - skopeo
   - podman-docker
+  - fuse-overlayfs
+  - slirp4netns
 
 artifacts:
 - name: entrypoint.sh

--- a/modules/developer-base/setup-entrypoint.sh
+++ b/modules/developer-base/setup-entrypoint.sh
@@ -5,10 +5,11 @@ chown 0:0 /entrypoint.sh
 # Setup $PS1 for a consistent and reasonable prompt
 echo "export PS1='\W \`git branch --show-current 2>/dev/null | sed -r -e \"s@^(.+)@\(\1\) @\"\`$ '" >> /home/user/.bashrc
 # Set permissions on /etc/passwd and /home to allow arbitrary users to write
-chgrp -R 0 /home
+chgrp -R 0 /home /etc/passwd /etc/group /etc/subuid /etc/subgid /home ${WORK_DIR}
 
 # Setup for root-less podman
 mkdir -p "${HOME}"/.config/containers;
+mkdir -p "${HOME}/.cache"
 setcap cap_setuid+ep /usr/bin/newuidmap;
 setcap cap_setgid+ep /usr/bin/newgidmap;
 touch /etc/subgid /etc/subuid;


### PR DESCRIPTION
Test instructions:

pull down latest quay.io/etsauer/cekit-builder:dev into a workspace and check that by default, oh-my-zsh pops up as your terminal prompt, and no error messages show in terminal