### PR TITLE
Add support to modify env with ${PROJECT_SOURCE}/workspace.rc on workspace startup

### DIFF
--- a/modules/developer-base/entrypoint.sh
+++ b/modules/developer-base/entrypoint.sh
@@ -23,11 +23,13 @@ echo "${USER}:${START_ID}:2147483646" > /etc/subgid
 # Setup $PS1 for a consistent and reasonable prompt
 if [ -w "${HOME}" ] && [ ! -f "${HOME}"/.bashrc ]; then
   echo "PS1='[\u@\h \W]\$ '" > "${HOME}"/.bashrc
+  (echo "if [ -f ${PROJECT_SOURCE}/workspace.rc ]"; echo "then"; echo "  . ${PROJECT_SOURCE}/workspace.rc"; echo "fi") > ${HOME}/.bashrc
 fi
 
-if [ ! -f ${HOME}/.zshrc ]
+if [ -w "${HOME}" ] && [ ! -f ${HOME}/.zshrc ]
 then
   (echo "HISTFILE=${HOME}/.zsh_history"; echo "HISTSIZE=1000"; echo "SAVEHIST=1000") > ${HOME}/.zshrc
+  (echo "if [ -f ${PROJECT_SOURCE}/workspace.rc ]"; echo "then"; echo "  . ${PROJECT_SOURCE}/workspace.rc"; echo "fi") >> ${HOME}/.zshrc
 fi
 
 podman login -u $(oc whoami) -p $(oc whoami -t)  image-registry.openshift-image-registry.svc:5000


### PR DESCRIPTION
When a workspace is started, if a file ${PROJECT_SOURCE}/workspace.rc exists, then it will be sourced by the shell to modify the shell environment.

Example: [https://github.com/cgruver/devspaces-backstage-plugin/blob/main/workspace.rc](https://github.com/cgruver/devspaces-backstage-plugin/blob/main/workspace.rc)