### PR TITLE
Fix UID/GID on Helm and Kustomize

### DIFF
--- a/modules/openshift-tools/helm.sh
+++ b/modules/openshift-tools/helm.sh
@@ -4,5 +4,6 @@ arch=linux-amd64
 curl -sLO "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/helm/${version}/helm-${arch}.tar.gz"
 tar xzf ./helm-${arch}.tar.gz
 mv ./helm-${arch} /usr/bin/helm
+chown root:root /usr/bin/helm
 helm version
 echo "😎😎😎😎😎"

--- a/modules/openshift-tools/kustomize.sh
+++ b/modules/openshift-tools/kustomize.sh
@@ -4,5 +4,6 @@ arch=linux_amd64
 curl -sLO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${version}/kustomize_${version}_${arch}.tar.gz"
 tar xzf ./kustomize_${version}_${arch}.tar.gz
 mv ./kustomize /usr/bin/
+chown root:root /usr/bin/kustomize
 kustomize version
 echo "😎😎😎😎😎"


### PR DESCRIPTION
The tar archives for helm and kustomize have non-root uids.

The large uid on helm causes podman issues with users who have a limited uid/gid in their namespace.