### PR TITLE
Provide an image for Apache Camel

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ 'cekit-builder', 'devspaces-base', 'devspaces-openjdk-17', 'devspaces-nodejs-18', 'devspaces-nodejs-20', 'devspaces-java-node-combined', 'devspaces-nested-podman', 'devspaces-python-311', 'devspaces-java21-node20-python311', 'devspaces-dotnet-8' ]
+        image: [ 'cekit-builder', 'devspaces-base', 'devspaces-openjdk-17', 'devspaces-nodejs-18', 'devspaces-nodejs-20', 'devspaces-java-node-combined', 'devspaces-nested-podman', 'devspaces-python-311', 'devspaces-java21-node20-python311', 'devspaces-dotnet-8', 'devspaces-camel' ]
     uses: ./.github/workflows/cekit-build.yaml
     with:
       tag: quay.io/redhat-cop/${{ matrix.image }}:latest

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ 'cekit-builder', 'devspaces-base', 'devspaces-openjdk-17', 'devspaces-nodejs-18', 'devspaces-nodejs-20', 'devspaces-java-node-combined', 'devspaces-nested-podman', 'devspaces-python-311', 'devspaces-java21-node20-python311', 'devspaces-dotnet-8' ]
+        image: [ 'cekit-builder', 'devspaces-base', 'devspaces-openjdk-17', 'devspaces-nodejs-18', 'devspaces-nodejs-20', 'devspaces-java-node-combined', 'devspaces-nested-podman', 'devspaces-python-311', 'devspaces-java21-node20-python311', 'devspaces-dotnet-8', 'devspaces-camel' ]
     uses: ./.github/workflows/cekit-build.yaml
     with:
       tag: quay.io/redhat-cop/${{ matrix.image }}:pr-${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This is useful for supporting a mixed mode where you want to have a streamlined 
 ```bash
 cekit build --overrides images/cekit-builder.yaml podman
 cekit build --overrides images/devspaces-base.yaml podman
+cekit build --overrides images/devspaces-camel.yaml podman
 cekit build --overrides images/devspaces-openjdk-17.yaml podman
 cekit build --overrides images/devspaces-nodejs-18.yaml podman
 cekit build --overrides images/devspaces-nodejs-20.yaml podman

--- a/images/devspaces-camel.yaml
+++ b/images/devspaces-camel.yaml
@@ -1,0 +1,9 @@
+name: devspaces-camel
+from: registry.access.redhat.com/ubi9/openjdk-21:1.20
+version: &version 1.0
+packages:
+  manager: microdnf
+modules:
+  install:
+  - name: jbang
+  - name: camel

--- a/images/devspaces-java-node-combined.yaml
+++ b/images/devspaces-java-node-combined.yaml
@@ -12,3 +12,4 @@ modules:
   - name: node20
   - name: angular
   - name: quarkus
+  - name: jbang

--- a/images/devspaces-java21-node20-python311.yaml
+++ b/images/devspaces-java21-node20-python311.yaml
@@ -12,4 +12,5 @@ modules:
   - name: node20
   - name: angular
   - name: quarkus
+  - name: jbang
   - name: python3.11

--- a/images/devspaces-nested-podman-fedora.yaml
+++ b/images/devspaces-nested-podman-fedora.yaml
@@ -15,6 +15,7 @@ modules:
   - name: java21
   - name: maven
   - name: quarkus
+  - name: jbang
   - name: node18
 run:
   entrypoint:

--- a/images/devspaces-nested-podman.yaml
+++ b/images/devspaces-nested-podman.yaml
@@ -13,6 +13,7 @@ modules:
   - name: java21
   - name: maven
   - name: quarkus
+  - name: jbang
 run:
   entrypoint:
   - "/entrypoint-nested.sh"

--- a/modules/camel/install.sh
+++ b/modules/camel/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+jbang trust add https://github.com/apache
+# Need to be able to specify the version in another iteration
+jbang app install camel@apache/camel
+
+# Hacky way to have camel on cli in the container.
+# The jbang app install is supposed to add it but it is adding the PATH which is not saved throigh the container.
+cd /usr/local/bin
+ln /usr/local/jbang/bin/camel camel

--- a/modules/camel/module.yaml
+++ b/modules/camel/module.yaml
@@ -1,0 +1,6 @@
+schema_version: 1
+name: camel
+version: v1.0
+description: "Confgure JBang and install Camel CLI"
+execute:
+- script: install.sh

--- a/modules/jbang/install.sh
+++ b/modules/jbang/install.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mkdir -p ${JBANG_DIR}
+curl -Ls https://sh.jbang.dev | bash -s - app setup
+ln -s ${JBANG_DIR}/bin/jbang /usr/local/bin/jbang

--- a/modules/jbang/module.yaml
+++ b/modules/jbang/module.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+name: jbang
+version: v1.0
+description: "Installs JBang CLI"
+envs:
+- name: JBANG_DIR
+  value: "/usr/local/jbang"
+execute:
+- script: install.sh

--- a/modules/quarkus/install.sh
+++ b/modules/quarkus/install.sh
@@ -11,6 +11,3 @@ chmod +x /usr/local/quarkus-cli/bin/quarkus
 rm -rf "${TEMP_DIR}" 
 cd /usr/local/bin
 ln -s ../quarkus-cli/bin/quarkus quarkus
-mkdir -p ${JBANG_DIR}
-curl -Ls https://sh.jbang.dev | bash -s - app setup
-ln -s ${JBANG_DIR}/bin/jbang /usr/local/bin/jbang

--- a/modules/quarkus/module.yaml
+++ b/modules/quarkus/module.yaml
@@ -5,8 +5,5 @@ description: "Installs the Quarkus CLI"
 args:
 - name: QUARKUS_VERSION
   value: 3.6.6
-envs:
-- name: JBANG_DIR
-  value: "/usr/local/jbang"
 execute:
 - script: install.sh


### PR DESCRIPTION
fixes #30

includes jbang cli configured to accept github.com/apache as trusted domain and Camel CLI

Note that jbang installation has been extracted to its own module as it is used by both Camel and Quarkus