### PR TITLE
Add aws-cli to the devspaces-base image

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -22,4 +22,5 @@ modules:
   - name: developer-base
   - name: custom-tooling
   - name: openshift-tools
+  - name: aws-cli
   - name: yq


### PR DESCRIPTION
Since basically all clusters consume some form of s3, aws cli is pretty universally useful